### PR TITLE
api: support filtering category/price/rating

### DIFF
--- a/food/api/.brewfile
+++ b/food/api/.brewfile
@@ -1,3 +1,4 @@
 brew 'asdf'
 brew 'heroku/brew/heroku'
 brew 'postgresql'
+brew 'postgis'

--- a/food/api/Gemfile
+++ b/food/api/Gemfile
@@ -13,6 +13,7 @@ gem 'geocoder'
 gem 'awesome_print'
 gem 'fcm'
 gem 'bitly'
+gem 'activerecord-postgis-adapter'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/food/api/Gemfile.lock
+++ b/food/api/Gemfile.lock
@@ -33,6 +33,9 @@ GEM
       activemodel (= 5.2.1)
       activesupport (= 5.2.1)
       arel (>= 9.0)
+    activerecord-postgis-adapter (5.2.2)
+      activerecord (~> 5.1)
+      rgeo-activerecord (~> 6.0)
     activestorage (5.2.1)
       actionpack (= 5.2.1)
       activerecord (= 5.2.1)
@@ -183,6 +186,10 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     remotipart (1.4.2)
+    rgeo (2.0.0)
+    rgeo-activerecord (6.1.0)
+      activerecord (~> 5.0)
+      rgeo (>= 1.0.0)
     ruby_dep (1.5.0)
     sass (3.7.2)
       sass-listen (~> 4.0.0)
@@ -223,6 +230,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-postgis-adapter
   awesome_print
   bitly
   bootsnap (>= 1.1.0)

--- a/food/api/app/controllers/application_controller.rb
+++ b/food/api/app/controllers/application_controller.rb
@@ -1,5 +1,11 @@
 class ApplicationController < ActionController::API
+
+  def force_compression
+    request.env['HTTP_ACCEPT_ENCODING'] = 'gzip'
+  end
+
   def force_exception
     raise "Forced exception."
   end
+
 end

--- a/food/api/app/controllers/categories_controller.rb
+++ b/food/api/app/controllers/categories_controller.rb
@@ -1,0 +1,16 @@
+class CategoriesController < ApplicationController
+
+  before_action :force_compression
+
+  def index
+    data = Category.all
+    render json: {
+      meta: {
+        count: data.size
+      },
+      data: data
+    }
+  end
+
+end
+

--- a/food/api/app/models/categorization.rb
+++ b/food/api/app/models/categorization.rb
@@ -1,7 +1,7 @@
 class Categorization < ApplicationRecord
 
-  belongs_to :place, dependent: :destroy
-  belongs_to :category, dependent: :destroy
+  belongs_to :place, touch: true
+  belongs_to :category, touch: true
 
   validates :place, :category, presence: true
   validates :place, uniqueness: { scope: :category }

--- a/food/api/app/models/category.rb
+++ b/food/api/app/models/category.rb
@@ -4,7 +4,7 @@ class Category < ApplicationRecord
     presence: true,
     uniqueness: true
 
-  has_many :categorizations
+  has_many :categorizations, dependent: :destroy
   has_many :places, through: :categorizations
 
   rails_admin do
@@ -18,6 +18,15 @@ class Category < ApplicationRecord
 
   def admin_name
     name
+  end
+
+  def as_json(options = nil)
+    super({
+      only: [
+        :identifier,
+        :name,
+      ],
+    }.merge(options || {}))
   end
 
 end

--- a/food/api/config/database.yml
+++ b/food/api/config/database.yml
@@ -1,10 +1,10 @@
 default: &default
-  adapter: postgresql
+  adapter: postgis
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  url: <%= ENV['DATABASE_URL'] %>
+  url: <%= ENV['DATABASE_URL'].sub(/^postgres/, "postgis") %> # https://git.io/fhQZr
 
 development:
   <<: *default

--- a/food/api/config/routes.rb
+++ b/food/api/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   resources :places, only: :index
+  resources :categories, only: :index
 
   # static pages
   get "/privacy", to: redirect("privacy.html")

--- a/food/api/db/migrate/20190211150502_add_postgis.rb
+++ b/food/api/db/migrate/20190211150502_add_postgis.rb
@@ -1,0 +1,10 @@
+class AddPostgis < ActiveRecord::Migration[5.2]
+  def change
+    enable_extension :postgis
+    change_table(:places) do |t|
+      t.st_point :lonlat, geographic: true
+      t.index :lonlat, using: :gist
+    end
+  end
+end
+

--- a/food/api/db/migrate/20190211175637_index_facets.rb
+++ b/food/api/db/migrate/20190211175637_index_facets.rb
@@ -1,0 +1,12 @@
+class IndexFacets < ActiveRecord::Migration[5.2]
+  def change
+    change_table :posts do |t|
+      t.index :rating
+      t.index :price, using: :gin
+    end
+    change_table :places do |t|
+      t.string :category_identifiers, array: true, default: []
+      t.index :category_identifiers, using: :gin
+    end
+  end
+end

--- a/food/api/db/schema.rb
+++ b/food/api/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_04_111024) do
+ActiveRecord::Schema.define(version: 2019_02_11_175637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "postgis"
   enable_extension "uuid-ossp"
 
   create_table "categories", force: :cascade do |t|
@@ -47,7 +48,11 @@ ActiveRecord::Schema.define(version: 2019_02_04_111024) do
     t.string "address", null: false
     t.string "phone"
     t.string "website"
+    t.geography "lonlat", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
+    t.string "category_identifiers", default: [], array: true
+    t.index ["category_identifiers"], name: "index_places_on_category_identifiers", using: :gin
     t.index ["identifier"], name: "index_places_on_identifier"
+    t.index ["lonlat"], name: "index_places_on_lonlat", using: :gist
     t.index ["name"], name: "index_places_on_name"
   end
 
@@ -65,6 +70,8 @@ ActiveRecord::Schema.define(version: 2019_02_04_111024) do
     t.string "source_key", null: false
     t.index ["identifier"], name: "index_posts_on_identifier"
     t.index ["place_id"], name: "index_posts_on_place_id"
+    t.index ["price"], name: "index_posts_on_price", using: :gin
+    t.index ["rating"], name: "index_posts_on_rating"
   end
 
 end


### PR DESCRIPTION
PTAL @achainan 	

Note that the filter param keys are plural (`categories, ratings, prices`) to support arrays of values (`UUID`, `Int`), but can accept single values too.

Live on stag, sample query w/ a category:
https://food-stag.lenfestlab.org/places.json?lat=39.9526&limit=1000&lng=-75.1652&categories=b96a877f-52e8-414f-a8f6-cbd98c7c9e7f

Also, migrated to PostGIS so pls rerun `bootstrap.sh` to run API locally.