### PR TITLE
[food][api] add Category#is_cuisine, bar reviews

### DIFF
--- a/food/api/app/controllers/categories_controller.rb
+++ b/food/api/app/controllers/categories_controller.rb
@@ -3,7 +3,7 @@ class CategoriesController < ApplicationController
   before_action :force_compression
 
   def index
-    data = Category.all
+    data = Category.cuisine(params[:is_cuisine])
     render json: {
       meta: {
         count: data.size

--- a/food/api/app/models/category.rb
+++ b/food/api/app/models/category.rb
@@ -7,6 +7,10 @@ class Category < ApplicationRecord
   has_many :categorizations, dependent: :destroy
   has_many :places, through: :categorizations
 
+  def image_url
+    Post.ensure_https read_attribute(:image_urls).first
+  end
+
   rails_admin do
     object_label_method :admin_name
     %i{
@@ -32,6 +36,9 @@ class Category < ApplicationRecord
         :is_cuisine,
         :name,
       ],
+      methods: [
+        :image_url,
+      ]
     }.merge(options || {}))
   end
 

--- a/food/api/app/models/category.rb
+++ b/food/api/app/models/category.rb
@@ -9,7 +9,12 @@ class Category < ApplicationRecord
 
   rails_admin do
     object_label_method :admin_name
-    [:identifier, :created_at, :updated_at, :key, :categorizations].each do |hidden_attr|
+    %i{
+      identifier
+      created_at
+      updated_at
+      categorizations
+    }.each do |hidden_attr|
       configure hidden_attr do
         hide
       end
@@ -24,6 +29,7 @@ class Category < ApplicationRecord
     super({
       only: [
         :identifier,
+        :is_cuisine,
         :name,
       ],
     }.merge(options || {}))

--- a/food/api/app/models/category.rb
+++ b/food/api/app/models/category.rb
@@ -11,6 +11,9 @@ class Category < ApplicationRecord
     Post.ensure_https read_attribute(:image_urls).first
   end
 
+  ## Admin
+  #
+
   rails_admin do
     object_label_method :admin_name
     %i{
@@ -28,6 +31,15 @@ class Category < ApplicationRecord
   def admin_name
     name
   end
+
+  ## Filters
+  #
+
+  scope :cuisine, -> (value) {
+    if value.present?
+      where(is_cuisine: value)
+    end
+  }
 
   def as_json(options = nil)
     super({

--- a/food/api/app/models/place.rb
+++ b/food/api/app/models/place.rb
@@ -25,7 +25,7 @@ class Place < ApplicationRecord
 
   scope :nearest, -> (lat, lng, kilometers = Place.default_search_radius) {
     distance_calc = "ST_Distance(lonlat, 'POINT(#{lng} #{lat})')"
-    select("places.*, #{distance_calc}")
+    select("places.*, #{distance_calc} as distance")
       .where("#{distance_calc} < #{kilometers * 1000.0}")
       .order("#{distance_calc} ASC")
   }
@@ -105,6 +105,7 @@ class Place < ApplicationRecord
         :identifier,
         :name,
         :address,
+        :distance,
       ],
       methods: [
         :location,

--- a/food/api/app/models/post.rb
+++ b/food/api/app/models/post.rb
@@ -12,7 +12,7 @@ class Post < ApplicationRecord
   validates :published_at, uniqueness: { scope: :place_id }
 
   def image_url
-    read_attribute(:image_urls).first
+    Post.ensure_https read_attribute(:image_urls).first
   end
 
   def url

--- a/food/api/db/migrate/20190228120833_add_category_cuisine.rb
+++ b/food/api/db/migrate/20190228120833_add_category_cuisine.rb
@@ -1,0 +1,5 @@
+class AddCategoryCuisine < ActiveRecord::Migration[5.2]
+  def change
+    add_column :categories, :is_cuisine, :boolean, default: false
+  end
+end

--- a/food/api/db/migrate/20190228161828_add_category_image_urls.rb
+++ b/food/api/db/migrate/20190228161828_add_category_image_urls.rb
@@ -1,0 +1,8 @@
+class AddCategoryImageUrls < ActiveRecord::Migration[5.2]
+  def change
+    change_table(:categories) do |t|
+      t.text :image_urls, array: true, default: []
+    end
+  end
+end
+

--- a/food/api/db/schema.rb
+++ b/food/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_27_223749) do
+ActiveRecord::Schema.define(version: 2019_02_28_120833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2019_02_27_223749) do
     t.uuid "identifier", default: -> { "uuid_generate_v4()" }
     t.string "name", null: false
     t.string "key", null: false
+    t.boolean "is_cuisine", default: false
     t.index ["identifier"], name: "index_categories_on_identifier"
     t.index ["key"], name: "index_categories_on_key", unique: true
   end

--- a/food/api/db/schema.rb
+++ b/food/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_28_120833) do
+ActiveRecord::Schema.define(version: 2019_02_28_161828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2019_02_28_120833) do
     t.string "name", null: false
     t.string "key", null: false
     t.boolean "is_cuisine", default: false
+    t.text "image_urls", default: [], array: true
     t.index ["identifier"], name: "index_categories_on_identifier"
     t.index ["key"], name: "index_categories_on_key", unique: true
   end

--- a/food/api/db/seeds.rb
+++ b/food/api/db/seeds.rb
@@ -66,6 +66,8 @@ _reviews.each do |review|
     Categorization.create(place: place, category: category_classic)
   end
 
+#Leadimg
+
 end
 
 _categories = _data["sections"]
@@ -75,7 +77,16 @@ _categories.each do |key, obj|
   places_node = obj.find { |node| node["type"] == "restaurants"}
   place_names = places_node["value"] if places_node
   next unless name && place_names.present?
-  category = Category.create(key: key, name: name)
+  category =
+    Category.find_by_key(key) ||
+    Category.create(key: key, name: name)
+
+  image_urls_node = obj.find { |node| node["type"] == "Leadimg"}
+  image_url = image_urls_node["value"] if image_urls_node
+  category.update_attributes!({
+    image_urls: [image_url]
+  })
+
   places = Place.where(name: place_names)
   places.each { |place| Categorization.create(place: place, category: category) }
 end
@@ -125,6 +136,10 @@ _bar_data.each do |row|
     Category.create(key: key, name: name)
   Categorization.create(place: place, category: category)
 
+  category.update_attributes!({
+    image_urls: [row[:image]]
+  })
+
   url = row[:link]
   attrs = {
     place: place,
@@ -170,8 +185,24 @@ classic
 chinatown
 readingmarket
 =end
+
+_backfilled_category_images = {
+  classic: "http://media.philly.com/storage/inquirer/projects/dining-guide-2018/photos/dg-classics-landingpage.jpg",
+  top25: "http://media.philly.com/storage/inquirer/projects/dining-guide-2018/photos/RS1241068_AECRAIG12-A-1.JPG",
+  pizza: "http://media.philly.com/storage/inquirer/projects/dining-guide-2018/photos/pizzaphoto-1.jpg",
+  sandwiches: "http://media.philly.com/storage/inquirer/projects/dining-guide-2018/photos/RS1249817_DGCLASSICS18-m.jpg"
+}
+
 Category.all.each do |category|
-  category.update_attributes!({
-    is_cuisine: _cuisine_keys.include?(category.key)
-  })
+  key = category.key
+  attrs = {
+    is_cuisine: _cuisine_keys.include?(key)
+  }
+  if image_url = _backfilled_category_images[key.to_sym]
+    attrs.merge!({
+      image_urls: [image_url]
+    })
+  end
+  category.update_attributes!(attrs)
 end
+

--- a/food/api/db/seeds.rb
+++ b/food/api/db/seeds.rb
@@ -96,3 +96,82 @@ _photos.reduce({}) { |map, o|
     post.save
   end
 end
+
+## Bars
+# src data: https://goo.gl/svbxoM
+def csv filedir, filename
+  CSV.read("#{filedir}/#{filename}.csv", {
+    headers: true,
+    header_converters: :symbol,
+  })
+end
+
+_bar_data = csv(dir, "bars")
+_bar_data.each do |row|
+  name = row[:name]
+  place =
+    Place.find_by_name(name) ||
+    Place.create({
+      name: name,
+      address: row[:address],
+      lat: row[:lat],
+      lng: row[:long],
+    })
+
+  name = row[:type]
+  key = name.downcase.gsub(/[[:space:]]/, '')
+  category =
+    Category.find_by_key(key) ||
+    Category.create(key: key, name: name)
+  Categorization.create(place: place, category: category)
+
+  url = row[:link]
+  attrs = {
+    place: place,
+    published_at: guide_date,
+    blurb: row[:description],
+    url: url,
+    source_key: url,
+    image_urls: [row[:image]]
+  }
+
+  Post.create(attrs)
+end
+
+
+## Cuisine
+#
+_cuisine_keys = %w{
+seafood
+italian
+middleeastern
+french
+mexican
+japanese
+vegetables
+modernamerican
+chinese
+southeastasian
+dinersdelis
+sandwiches
+gastropubs
+chops
+pizza
+soulfood
+polish
+korean
+borschtbelt
+latino
+}
+=begin
+Key
+top25
+classic
+chinatown
+readingmarket
+=end
+Category.all.each do |category|
+  category.update_attributes!({
+    is_cuisine: _cuisine_keys.include?(category.key)
+  })
+end


### PR DESCRIPTION
@achainan PTAL (live on stag).

Turns out that _most_ of our current categories could be classified as a "cuisine," so if we model them as mutually exclusive to `categories` we'll be left with few potential "guides." So instead of distinct models/tables, this adds an `is_cuisine` boolean flag to `Category`, and we can divide them between "guides" and "cuisines" when queried.

New flag is visible here:
https://food-stag.lenfestlab.org/categories.json
https://food-stag.lenfestlab.org/admin/category

Also imported the bar data.